### PR TITLE
typeck: adding type information to projection

### DIFF
--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -488,7 +488,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     ) {
         if let mc::PlaceBase::Rvalue = place_with_id.place.base {
             if place_with_id.place.projections.is_empty() {
-                let typ = self.resolve_type(place_with_id.place.ty);
+                let typ = self.resolve_type(place_with_id.place.ty());
                 let body_id = self.body_id;
                 let _ = dropck::check_drop_obligations(self, typ, span, body_id);
             }
@@ -640,8 +640,8 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         borrow_kind: ty::BorrowKind,
         borrow_place: &mc::PlaceWithHirId<'tcx>,
     ) {
-        let origin = infer::DataBorrowed(borrow_place.place.ty, span);
-        self.type_must_outlive(origin, borrow_place.place.ty, borrow_region);
+        let origin = infer::DataBorrowed(borrow_place.place.ty(), span);
+        self.type_must_outlive(origin, borrow_place.place.ty(), borrow_region);
 
         for pointer_ty in borrow_place.place.deref_tys() {
             debug!(

--- a/src/librustc_typeck/expr_use_visitor.rs
+++ b/src/librustc_typeck/expr_use_visitor.rs
@@ -384,7 +384,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
 
         // Select just those fields of the `with`
         // expression that will actually be used
-        match with_place.place.ty.kind {
+        match with_place.place.ty().kind {
             ty::Adt(adt, substs) if adt.is_struct() => {
                 // Consume those fields of the with expression that are needed.
                 for (f_index, with_field) in adt.non_enum_variant().fields.iter().enumerate() {
@@ -583,7 +583,7 @@ fn copy_or_move<'a, 'tcx>(
     place_with_id: &PlaceWithHirId<'tcx>,
 ) -> ConsumeMode {
     if !mc.type_is_copy_modulo_regions(
-        place_with_id.place.ty,
+        place_with_id.place.ty(),
         mc.tcx().hir().span(place_with_id.hir_id),
     ) {
         Move

--- a/src/tools/clippy/clippy_lints/src/escape.rs
+++ b/src/tools/clippy/clippy_lints/src/escape.rs
@@ -150,7 +150,7 @@ impl<'a, 'tcx> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
                     return;
                 }
 
-                if is_non_trait_box(cmt.place.ty) && !self.is_large_box(cmt.place.ty) {
+                if is_non_trait_box(cmt.place.ty()) && !self.is_large_box(cmt.place.ty()) {
                     self.set.insert(cmt.hir_id);
                 }
                 return;


### PR DESCRIPTION
This commit modifies the Place as follow:
* remove 'ty' from ProjectionKind
* added 'before_ty' and 'after_ty' to Projection
* replace 'ty' in Place with 'base_ty'
* introduce 'ty()' in Place to return the final type of the Place

Closes https://github.com/rust-lang/project-rfc-2229/issues/5