### PR TITLE
Replace closures_captures and upvar_capture with closure_min_captures

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -29,9 +29,7 @@ use rustc_attr as attr;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sharded::{IntoPointer, ShardedHashMap};
-use rustc_data_structures::stable_hasher::{
-    hash_stable_hashmap, HashStable, StableHasher, StableVec,
-};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableVec};
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{self, Lock, Lrc, WorkerLocal};
 use rustc_errors::ErrorReported;
@@ -373,9 +371,6 @@ pub struct TypeckResults<'tcx> {
     /// <https://github.com/rust-lang/rfcs/blob/master/text/2005-match-ergonomics.md#definitions>
     pat_adjustments: ItemLocalMap<Vec<Ty<'tcx>>>,
 
-    /// Borrows
-    pub upvar_capture_map: ty::UpvarCaptureMap<'tcx>,
-
     /// Records the reasons that we picked the kind of each closure;
     /// not all closures are present in the map.
     closure_kind_origins: ItemLocalMap<(Span, Symbol)>,
@@ -411,12 +406,6 @@ pub struct TypeckResults<'tcx> {
     /// by this function.
     pub concrete_opaque_types: FxHashMap<DefId, ResolvedOpaqueTy<'tcx>>,
 
-    /// Given the closure ID this map provides the list of UpvarIDs used by it.
-    /// The upvarID contains the HIR node ID and it also contains the full path
-    /// leading to the member of the struct or tuple that is used instead of the
-    /// entire variable.
-    pub closure_captures: ty::UpvarListMap,
-
     /// Tracks the minimum captures required for a closure;
     /// see `MinCaptureInformationMap` for more details.
     pub closure_min_captures: ty::MinCaptureInformationMap<'tcx>,
@@ -445,7 +434,6 @@ impl<'tcx> TypeckResults<'tcx> {
             adjustments: Default::default(),
             pat_binding_modes: Default::default(),
             pat_adjustments: Default::default(),
-            upvar_capture_map: Default::default(),
             closure_kind_origins: Default::default(),
             liberated_fn_sigs: Default::default(),
             fru_field_types: Default::default(),
@@ -453,7 +441,6 @@ impl<'tcx> TypeckResults<'tcx> {
             used_trait_imports: Lrc::new(Default::default()),
             tainted_by_errors: None,
             concrete_opaque_types: Default::default(),
-            closure_captures: Default::default(),
             closure_min_captures: Default::default(),
             generator_interior_types: Default::default(),
             treat_byte_string_as_slice: Default::default(),
@@ -637,10 +624,6 @@ impl<'tcx> TypeckResults<'tcx> {
             .flatten()
     }
 
-    pub fn upvar_capture(&self, upvar_id: ty::UpvarId) -> ty::UpvarCapture<'tcx> {
-        self.upvar_capture_map[&upvar_id]
-    }
-
     pub fn closure_kind_origins(&self) -> LocalTableInContext<'_, (Span, Symbol)> {
         LocalTableInContext { hir_owner: self.hir_owner, data: &self.closure_kind_origins }
     }
@@ -682,7 +665,7 @@ impl<'tcx> TypeckResults<'tcx> {
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ty::TypeckResults {
-            hir_owner,
+            hir_owner: _,
             ref type_dependent_defs,
             ref field_indices,
             ref user_provided_types,
@@ -692,17 +675,13 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             ref adjustments,
             ref pat_binding_modes,
             ref pat_adjustments,
-            ref upvar_capture_map,
             ref closure_kind_origins,
             ref liberated_fn_sigs,
             ref fru_field_types,
-
             ref coercion_casts,
-
             ref used_trait_imports,
             tainted_by_errors,
             ref concrete_opaque_types,
-            ref closure_captures,
             ref closure_min_captures,
             ref generator_interior_types,
             ref treat_byte_string_as_slice,
@@ -718,17 +697,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             adjustments.hash_stable(hcx, hasher);
             pat_binding_modes.hash_stable(hcx, hasher);
             pat_adjustments.hash_stable(hcx, hasher);
-            hash_stable_hashmap(hcx, hasher, upvar_capture_map, |up_var_id, hcx| {
-                let ty::UpvarId { var_path, closure_expr_id } = *up_var_id;
-
-                assert_eq!(var_path.hir_id.owner, hir_owner);
-
-                (
-                    hcx.local_def_path_hash(var_path.hir_id.owner),
-                    var_path.hir_id.local_id,
-                    hcx.local_def_path_hash(closure_expr_id),
-                )
-            });
 
             closure_kind_origins.hash_stable(hcx, hasher);
             liberated_fn_sigs.hash_stable(hcx, hasher);
@@ -737,7 +705,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             used_trait_imports.hash_stable(hcx, hasher);
             tainted_by_errors.hash_stable(hcx, hasher);
             concrete_opaque_types.hash_stable(hcx, hasher);
-            closure_captures.hash_stable(hcx, hasher);
             closure_min_captures.hash_stable(hcx, hasher);
             generator_interior_types.hash_stable(hcx, hasher);
             treat_byte_string_as_slice.hash_stable(hcx, hasher);

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
@@ -388,7 +388,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     //
                     // We know the field exists so it's safe to call operator[] and `unwrap` here.
                     let (&var_id, _) =
-                        self.infcx.tcx.typeck(def_id.expect_local()).closure_captures[&def_id]
+                        self.infcx.tcx.typeck(def_id.expect_local()).closure_min_captures[&def_id]
                             .get_index(field.index())
                             .unwrap();
 
@@ -965,12 +965,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let expr = &self.infcx.tcx.hir().expect_expr(hir_id).kind;
         debug!("closure_span: hir_id={:?} expr={:?}", hir_id, expr);
         if let hir::ExprKind::Closure(.., body_id, args_span, _) = expr {
-            for (upvar_hir_id, place) in
-                self.infcx.tcx.typeck(def_id.expect_local()).closure_captures[&def_id]
-                    .keys()
-                    .zip(places)
+            for (captured_place, place) in self
+                .infcx
+                .tcx
+                .typeck(def_id.expect_local())
+                .closure_min_captures_flattened(def_id)
+                .zip(places)
             {
-                let span = self.infcx.tcx.upvars_mentioned(local_did)?[upvar_hir_id].span;
+                let span = self.infcx.tcx.hir().span(captured_place.info.expr_id.unwrap());
                 match place {
                     Operand::Copy(place) | Operand::Move(place)
                         if target_place == place.as_ref() =>
@@ -978,10 +980,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         debug!("closure_span: found captured local {:?}", place);
                         let body = self.infcx.tcx.hir().body(*body_id);
                         let generator_kind = body.generator_kind();
-                        let upvar_id = ty::UpvarId {
-                            var_path: ty::UpvarPath { hir_id: *upvar_hir_id },
-                            closure_expr_id: local_did,
-                        };
 
                         // If we have a more specific span available, point to that.
                         // We do this even though this span might be part of a borrow error
@@ -989,11 +987,11 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         // to a span that shows why the upvar is used in the closure,
                         // so a move-related span is as good as any (and potentially better,
                         // if the overall error is due to a move of the upvar).
-                        let usage_span =
-                            match self.infcx.tcx.typeck(local_did).upvar_capture(upvar_id) {
-                                ty::UpvarCapture::ByValue(Some(span)) => span,
-                                _ => span,
-                            };
+
+                        let usage_span = match captured_place.info.capture_kind {
+                            ty::UpvarCapture::ByValue(Some(span)) => span,
+                            _ => span,
+                        };
                         return Some((*args_span, generator_kind, usage_span));
                     }
                     _ => {}

--- a/compiler/rustc_mir/src/interpret/validity.rs
+++ b/compiler/rustc_mir/src/interpret/validity.rs
@@ -104,7 +104,7 @@ pub enum PathElem {
     Field(Symbol),
     Variant(Symbol),
     GeneratorState(VariantIdx),
-    CapturedVar(Symbol),
+    CapturedPlace(Symbol),
     ArrayElem(usize),
     TupleElem(usize),
     Deref,
@@ -162,7 +162,7 @@ fn write_path(out: &mut String, path: &Vec<PathElem>) {
             Variant(name) => write!(out, ".<enum-variant({})>", name),
             GeneratorTag => write!(out, ".<generator-tag>"),
             GeneratorState(idx) => write!(out, ".<generator-state({})>", idx.index()),
-            CapturedVar(name) => write!(out, ".<captured-var({})>", name),
+            CapturedPlace(name) => write!(out, ".<captured-var({})>", name),
             TupleElem(idx) => write!(out, ".{}", idx),
             ArrayElem(idx) => write!(out, "[{}]", idx),
             // `.<deref>` does not match Rust syntax, but it is more readable for long paths -- and
@@ -257,7 +257,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
                     }
                 }
 
-                PathElem::CapturedVar(name.unwrap_or_else(|| {
+                PathElem::CapturedPlace(name.unwrap_or_else(|| {
                     // Fall back to showing the field index.
                     sym::integer(field)
                 }))

--- a/compiler/rustc_mir/src/interpret/validity.rs
+++ b/compiler/rustc_mir/src/interpret/validity.rs
@@ -242,7 +242,8 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
                 let mut name = None;
                 if let Some(def_id) = def_id.as_local() {
                     let tables = self.ecx.tcx.typeck(def_id);
-                    if let Some(upvars) = tables.closure_captures.get(&def_id.to_def_id()) {
+
+                    if let Some(upvars) = tables.closure_min_captures.get(&def_id.to_def_id()) {
                         // Sometimes the index is beyond the number of upvars (seen
                         // for a generator).
                         if let Some((&var_hir_id, _)) = upvars.get_index(field) {

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -820,7 +820,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let hir_typeck_results = self.hir.typeck_results();
 
         // In analyze_closure() in upvar.rs we gathered a list of upvars used by a
-        // indexed closure and we stored in a map called closure_captures in TypeckResults
+        // indexed closure and we stored in a map called closure_min_captures in TypeckResults
         // with the closure's DefId. Here, we run through that vec of UpvarIds for
         // the given closure and use the necessary information to create upvar
         // debuginfo and to fill `self.upvar_mutbls`.

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -95,7 +95,7 @@ use rustc_hir::{Expr, HirId, HirIdMap, HirIdSet};
 use rustc_index::vec::IndexVec;
 use rustc_middle::hir::map::Map;
 use rustc_middle::ty::query::Providers;
-use rustc_middle::ty::{self, DefIdTree, TyCtxt};
+use rustc_middle::ty::{self, DefIdTree, RootVariableMinCaptureList, TyCtxt};
 use rustc_session::lint;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
@@ -331,7 +331,7 @@ impl<'tcx> Visitor<'tcx> for IrMaps<'tcx> {
             }
         }
 
-        if let Some(captures) = maps.tcx.typeck(local_def_id).closure_captures.get(&def_id) {
+        if let Some(captures) = maps.tcx.typeck(local_def_id).closure_min_captures.get(&def_id) {
             for &var_hir_id in captures.keys() {
                 let var_name = maps.tcx.hir().name(var_hir_id);
                 maps.add_variable(Upvar(var_hir_id, var_name));
@@ -403,7 +403,7 @@ impl<'tcx> Visitor<'tcx> for IrMaps<'tcx> {
                 if let Some(captures) = self
                     .tcx
                     .typeck(closure_def_id)
-                    .closure_captures
+                    .closure_min_captures
                     .get(&closure_def_id.to_def_id())
                 {
                     // If closure captures is Some, upvars_mentioned must also be Some
@@ -480,7 +480,8 @@ struct Liveness<'a, 'tcx> {
     typeck_results: &'a ty::TypeckResults<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     upvars: Option<&'tcx FxIndexMap<hir::HirId, hir::Upvar>>,
-    closure_captures: Option<&'tcx FxIndexMap<hir::HirId, ty::UpvarId>>,
+    // closure_captures: Option<&'tcx FxIndexMap<hir::HirId, ty::UpvarId>>,
+    closure_min_captures: Option<&'tcx RootVariableMinCaptureList<'tcx>>,
     successors: IndexVec<LiveNode, Option<LiveNode>>,
     rwu_table: rwu_table::RWUTable,
 
@@ -504,8 +505,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         let typeck_results = ir.tcx.typeck(body_owner);
         let param_env = ir.tcx.param_env(body_owner);
         let upvars = ir.tcx.upvars_mentioned(body_owner);
-        let closure_captures = typeck_results.closure_captures.get(&body_owner.to_def_id());
-
+        // let closure_captures = typeck_results.closure_captures.get(&body_owner.to_def_id());
+        let closure_min_captures = typeck_results.closure_min_captures.get(&body_owner.to_def_id());
         let closure_ln = ir.add_live_node(ClosureNode);
         let exit_ln = ir.add_live_node(ExitNode);
 
@@ -518,7 +519,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             typeck_results,
             param_env,
             upvars,
-            closure_captures,
+            // closure_captures,
+            closure_min_captures,
             successors: IndexVec::from_elem_n(None, num_live_nodes),
             rwu_table: rwu_table::RWUTable::new(num_live_nodes, num_vars),
             closure_ln,
@@ -702,25 +704,28 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         // if they are live on the entry to the closure, since only the closure
         // itself can access them on subsequent calls.
 
-        if let Some(closure_captures) = self.closure_captures {
+        if let Some(closure_min_captures) = self.closure_min_captures {
             // Mark upvars captured by reference as used after closure exits.
             // Since closure_captures is Some, upvars must exists too.
+            //closure_min_captures = MinCaptureInformationMap > RootVariableMinCaptureList > MinCaptureList > CapturedPlace > CaptureInfo > UpvarCapture
             let upvars = self.upvars.unwrap();
-            for (&var_hir_id, upvar_id) in closure_captures {
+            for (&var_hir_id, min_capture_list) in closure_min_captures {
                 let upvar = upvars[&var_hir_id];
-                match self.typeck_results.upvar_capture(*upvar_id) {
-                    ty::UpvarCapture::ByRef(_) => {
-                        let var = self.variable(var_hir_id, upvar.span);
-                        self.acc(self.exit_ln, var, ACC_READ | ACC_USE);
+                for captured_place in min_capture_list {
+                    match captured_place.info.capture_kind {
+                        ty::UpvarCapture::ByRef(_) => {
+                            let var = self.variable(var_hir_id, upvar.span);
+                            self.acc(self.exit_ln, var, ACC_READ | ACC_USE);
+                        }
+                        ty::UpvarCapture::ByValue(_) => {}
                     }
-                    ty::UpvarCapture::ByValue(_) => {}
                 }
             }
         }
 
         let succ = self.propagate_through_expr(&body.value, self.exit_ln);
 
-        if self.closure_captures.is_none() {
+        if self.closure_min_captures.is_none() {
             // Either not a closure, or closure without any captured variables.
             // No need to determine liveness of captured variables, since there
             // are none.
@@ -1190,7 +1195,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         match path.res {
             Res::Local(hid) => {
                 let in_upvars = self.upvars.map_or(false, |u| u.contains_key(&hid));
-                let in_captures = self.closure_captures.map_or(false, |c| c.contains_key(&hid));
+                let in_captures = self.closure_min_captures.map_or(false, |c| c.contains_key(&hid));
 
                 match (in_upvars, in_captures) {
                     (false, _) | (true, true) => self.access_var(hir_id, hid, succ, acc, path.span),
@@ -1390,51 +1395,58 @@ impl<'tcx> Liveness<'_, 'tcx> {
     }
 
     fn warn_about_unused_upvars(&self, entry_ln: LiveNode) {
-        let closure_captures = match self.closure_captures {
+        let closure_min_captures = match self.closure_min_captures {
             None => return,
-            Some(closure_captures) => closure_captures,
+            Some(closure_min_captures) => closure_min_captures,
         };
 
         // If closure_captures is Some(), upvars must be Some() too.
         let upvars = self.upvars.unwrap();
-        for &var_hir_id in closure_captures.keys() {
+        for (&var_hir_id, min_capture_list) in closure_min_captures {
             let upvar = upvars[&var_hir_id];
             let var = self.variable(var_hir_id, upvar.span);
-            let upvar_id = ty::UpvarId {
+            let _upvar_id = ty::UpvarId {
                 var_path: ty::UpvarPath { hir_id: var_hir_id },
                 closure_expr_id: self.body_owner,
             };
-            match self.typeck_results.upvar_capture(upvar_id) {
-                ty::UpvarCapture::ByValue(_) => {}
-                ty::UpvarCapture::ByRef(..) => continue,
-            };
-            if self.used_on_entry(entry_ln, var) {
-                if !self.live_on_entry(entry_ln, var) {
+
+            for captured_place in min_capture_list {
+                match captured_place.info.capture_kind {
+                    ty::UpvarCapture::ByValue(_) => {}
+                    ty::UpvarCapture::ByRef(..) => continue,
+                };
+
+                if self.used_on_entry(entry_ln, var) {
+                    if self.live_on_entry(entry_ln, var).is_none() {
+                        if let Some(name) = self.should_warn(var) {
+                            self.ir.tcx.struct_span_lint_hir(
+                                lint::builtin::UNUSED_ASSIGNMENTS,
+                                var_hir_id,
+                                vec![upvar.span],
+                                |lint| {
+                                    lint.build(&format!(
+                                        "value captured by `{}` is never read",
+                                        name
+                                    ))
+                                    .help("did you mean to capture by reference instead?")
+                                    .emit();
+                                },
+                            );
+                        }
+                    }
+                } else {
                     if let Some(name) = self.should_warn(var) {
                         self.ir.tcx.struct_span_lint_hir(
-                            lint::builtin::UNUSED_ASSIGNMENTS,
+                            lint::builtin::UNUSED_VARIABLES,
                             var_hir_id,
                             vec![upvar.span],
                             |lint| {
-                                lint.build(&format!("value captured by `{}` is never read", name))
+                                lint.build(&format!("unused variable: `{}`", name))
                                     .help("did you mean to capture by reference instead?")
                                     .emit();
                             },
                         );
                     }
-                }
-            } else {
-                if let Some(name) = self.should_warn(var) {
-                    self.ir.tcx.struct_span_lint_hir(
-                        lint::builtin::UNUSED_VARIABLES,
-                        var_hir_id,
-                        vec![upvar.span],
-                        |lint| {
-                            lint.build(&format!("unused variable: `{}`", name))
-                                .help("did you mean to capture by reference instead?")
-                                .emit();
-                        },
-                    );
                 }
             }
         }

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -1408,7 +1408,7 @@ impl<'tcx> Liveness<'_, 'tcx> {
                 };
 
                 if self.used_on_entry(entry_ln, var) {
-                    if self.live_on_entry(entry_ln, var).is_none() {
+                    if !self.live_on_entry(entry_ln, var) {
                         if let Some(name) = self.should_warn(var) {
                             self.ir.tcx.struct_span_lint_hir(
                                 lint::builtin::UNUSED_ASSIGNMENTS,

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let mut capture_information: FxIndexMap<Place<'tcx>, ty::CaptureInfo<'tcx>> =
             Default::default();
-        if !self.tcx.features().capture_disjoint_fields {
+        if !self.tcx.features().capture_disjoint_fields && std::env::var("SG_NEW").is_err() {
             if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
                 for (&var_hir_id, _) in upvars.iter() {
                     let place = self.place_for_root_variable(local_def_id, var_hir_id);

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -187,8 +187,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.compute_min_captures(closure_def_id, delegate);
         self.log_closure_min_capture_info(closure_def_id, span);
 
-        self.min_captures_to_closure_captures_bridge(closure_def_id);
-
         // Now that we've analyzed the closure, we know how each
         // variable is borrowed, and we know what traits the closure
         // implements (Fn vs FnMut etc). We now have some updates to do
@@ -251,77 +249,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             })
             .collect()
-    }
-
-    /// Bridge for closure analysis
-    /// ----------------------------
-    ///
-    /// For closure with DefId `c`, the bridge converts structures required for supporting RFC 2229,
-    /// to structures currently used in the compiler for handling closure captures.
-    ///
-    /// For example the following structure will be converted:
-    ///
-    /// closure_min_captures
-    /// foo -> [ {foo.x, ImmBorrow}, {foo.y, MutBorrow} ]
-    /// bar -> [ {bar.z, ByValue}, {bar.q, MutBorrow} ]
-    ///
-    /// to
-    ///
-    /// 1. closure_captures
-    /// foo -> UpvarId(foo, c), bar -> UpvarId(bar, c)
-    ///
-    /// 2. upvar_capture_map
-    /// UpvarId(foo,c) -> MutBorrow, UpvarId(bar, c) -> ByValue
-    fn min_captures_to_closure_captures_bridge(&self, closure_def_id: DefId) {
-        let mut closure_captures: FxIndexMap<hir::HirId, ty::UpvarId> = Default::default();
-        let mut upvar_capture_map = ty::UpvarCaptureMap::default();
-
-        if let Some(min_captures) =
-            self.typeck_results.borrow().closure_min_captures.get(&closure_def_id)
-        {
-            for (var_hir_id, min_list) in min_captures.iter() {
-                for captured_place in min_list {
-                    let place = &captured_place.place;
-                    let capture_info = captured_place.info;
-
-                    let upvar_id = match place.base {
-                        PlaceBase::Upvar(upvar_id) => upvar_id,
-                        base => bug!("Expected upvar, found={:?}", base),
-                    };
-
-                    assert_eq!(upvar_id.var_path.hir_id, *var_hir_id);
-                    assert_eq!(upvar_id.closure_expr_id, closure_def_id.expect_local());
-
-                    closure_captures.insert(*var_hir_id, upvar_id);
-
-                    let new_capture_kind =
-                        if let Some(capture_kind) = upvar_capture_map.get(&upvar_id) {
-                            // upvar_capture_map only stores the UpvarCapture (CaptureKind),
-                            // so we create a fake capture info with no expression.
-                            let fake_capture_info =
-                                ty::CaptureInfo { expr_id: None, capture_kind: *capture_kind };
-                            determine_capture_info(fake_capture_info, capture_info).capture_kind
-                        } else {
-                            capture_info.capture_kind
-                        };
-                    upvar_capture_map.insert(upvar_id, new_capture_kind);
-                }
-            }
-        }
-        debug!("For closure_def_id={:?}, closure_captures={:#?}", closure_def_id, closure_captures);
-        debug!(
-            "For closure_def_id={:?}, upvar_capture_map={:#?}",
-            closure_def_id, upvar_capture_map
-        );
-
-        if !closure_captures.is_empty() {
-            self.typeck_results
-                .borrow_mut()
-                .closure_captures
-                .insert(closure_def_id, closure_captures);
-
-            self.typeck_results.borrow_mut().upvar_capture_map.extend(upvar_capture_map);
-        }
     }
 
     /// Analyzes the information collected by `InferBorrowKind` to compute the min number of

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -56,7 +56,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         wbcx.visit_body(body);
         wbcx.visit_min_capture_map();
-        // wbcx.visit_upvar_capture_map();
         wbcx.visit_closures();
         wbcx.visit_liberated_fn_sigs();
         wbcx.visit_fru_field_types();
@@ -73,9 +72,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         wbcx.typeck_results.treat_byte_string_as_slice =
             mem::take(&mut self.typeck_results.borrow_mut().treat_byte_string_as_slice);
-
-        // wbcx.typeck_results.closure_min_captures =
-        //     mem::take(&mut self.typeck_results.borrow_mut().closure_captures);
 
         if self.is_tainted_by_errors() {
             // FIXME(eddyb) keep track of `ErrorReported` from where the error was emitted.
@@ -362,22 +358,6 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
         self.typeck_results.closure_min_captures = min_captures_wb;
     }
-
-    // fn visit_upvar_capture_map(&mut self) {
-    //     for (upvar_id, upvar_capture) in self.fcx.typeck_results.borrow().upvar_capture_map.iter() {
-    //         let new_upvar_capture = match *upvar_capture {
-    //             ty::UpvarCapture::ByValue(span) => ty::UpvarCapture::ByValue(span),
-    //             ty::UpvarCapture::ByRef(ref upvar_borrow) => {
-    //                 ty::UpvarCapture::ByRef(ty::UpvarBorrow {
-    //                     kind: upvar_borrow.kind,
-    //                     region: self.tcx().lifetimes.re_erased,
-    //                 })
-    //             }
-    //         };
-    //         debug!("Upvar capture for {:?} resolved to {:?}", upvar_id, new_upvar_capture);
-    //         self.typeck_results.upvar_capture_map.insert(*upvar_id, new_upvar_capture);
-    //     }
-    // }
 
     fn visit_closures(&mut self) {
         let fcx_typeck_results = self.fcx.typeck_results.borrow();

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -56,7 +56,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         wbcx.visit_body(body);
         wbcx.visit_min_capture_map();
-        wbcx.visit_upvar_capture_map();
+        // wbcx.visit_upvar_capture_map();
         wbcx.visit_closures();
         wbcx.visit_liberated_fn_sigs();
         wbcx.visit_fru_field_types();
@@ -74,8 +74,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         wbcx.typeck_results.treat_byte_string_as_slice =
             mem::take(&mut self.typeck_results.borrow_mut().treat_byte_string_as_slice);
 
-        wbcx.typeck_results.closure_captures =
-            mem::take(&mut self.typeck_results.borrow_mut().closure_captures);
+        // wbcx.typeck_results.closure_min_captures =
+        //     mem::take(&mut self.typeck_results.borrow_mut().closure_captures);
 
         if self.is_tainted_by_errors() {
             // FIXME(eddyb) keep track of `ErrorReported` from where the error was emitted.
@@ -363,21 +363,21 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         self.typeck_results.closure_min_captures = min_captures_wb;
     }
 
-    fn visit_upvar_capture_map(&mut self) {
-        for (upvar_id, upvar_capture) in self.fcx.typeck_results.borrow().upvar_capture_map.iter() {
-            let new_upvar_capture = match *upvar_capture {
-                ty::UpvarCapture::ByValue(span) => ty::UpvarCapture::ByValue(span),
-                ty::UpvarCapture::ByRef(ref upvar_borrow) => {
-                    ty::UpvarCapture::ByRef(ty::UpvarBorrow {
-                        kind: upvar_borrow.kind,
-                        region: self.tcx().lifetimes.re_erased,
-                    })
-                }
-            };
-            debug!("Upvar capture for {:?} resolved to {:?}", upvar_id, new_upvar_capture);
-            self.typeck_results.upvar_capture_map.insert(*upvar_id, new_upvar_capture);
-        }
-    }
+    // fn visit_upvar_capture_map(&mut self) {
+    //     for (upvar_id, upvar_capture) in self.fcx.typeck_results.borrow().upvar_capture_map.iter() {
+    //         let new_upvar_capture = match *upvar_capture {
+    //             ty::UpvarCapture::ByValue(span) => ty::UpvarCapture::ByValue(span),
+    //             ty::UpvarCapture::ByRef(ref upvar_borrow) => {
+    //                 ty::UpvarCapture::ByRef(ty::UpvarBorrow {
+    //                     kind: upvar_borrow.kind,
+    //                     region: self.tcx().lifetimes.re_erased,
+    //                 })
+    //             }
+    //         };
+    //         debug!("Upvar capture for {:?} resolved to {:?}", upvar_id, new_upvar_capture);
+    //         self.typeck_results.upvar_capture_map.insert(*upvar_id, new_upvar_capture);
+    //     }
+    // }
 
     fn visit_closures(&mut self) {
         let fcx_typeck_results = self.fcx.typeck_results.borrow();

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
@@ -21,9 +21,9 @@ error[E0373]: async block may outlive the current function, but it borrows `x`, 
   --> $DIR/async-borrowck-escaping-block-error.rs:11:11
    |
 LL |     async { *x }
-   |           ^^^-^^
-   |           |  |
-   |           |  `x` is borrowed here
+   |           ^^--^^
+   |           | |
+   |           | `x` is borrowed here
    |           may outlive borrowed value `x`
    |
 note: async block is returned here

--- a/src/test/ui/borrowck/borrowck-closures-mut-and-imm.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-mut-and-imm.stderr
@@ -73,7 +73,7 @@ error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/borrowck-closures-mut-and-imm.rs:57:5
    |
 LL |     let c1 = || get(&*x);
-   |              --       - borrow occurs due to use in closure
+   |              --      -- borrow occurs due to use in closure
    |              |
    |              borrow of `*x` occurs here
 LL |     *x = 5;
@@ -86,7 +86,7 @@ error[E0506]: cannot assign to `*x.f` because it is borrowed
   --> $DIR/borrowck-closures-mut-and-imm.rs:69:5
    |
 LL |     let c1 = || get(&*x.f);
-   |              --       - borrow occurs due to use in closure
+   |              --      ---- borrow occurs due to use in closure
    |              |
    |              borrow of `*x.f` occurs here
 LL |     *x.f = 5;
@@ -99,11 +99,11 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
   --> $DIR/borrowck-closures-mut-and-imm.rs:81:14
    |
 LL |     let c1 = || get(&*x.f);
-   |              --       - first borrow occurs due to use of `x` in closure
+   |              --      ---- first borrow occurs due to use of `x` in closure
    |              |
    |              immutable borrow occurs here
 LL |     let c2 = || *x.f = 5;
-   |              ^^  - second borrow occurs due to use of `x` in closure
+   |              ^^ ---- second borrow occurs due to use of `x` in closure
    |              |
    |              mutable borrow occurs here
 LL |

--- a/src/test/ui/borrowck/borrowck-closures-mut-of-imm.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-mut-of-imm.stderr
@@ -14,12 +14,12 @@ error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/borrowck-closures-mut-of-imm.rs:11:18
    |
 LL |     let mut c1 = || set(&mut *x);
-   |                  --           - first borrow occurs due to use of `x` in closure
+   |                  --          -- first borrow occurs due to use of `x` in closure
    |                  |
    |                  first closure is constructed here
 LL |
 LL |     let mut c2 = || set(&mut *x);
-   |                  ^^           - second borrow occurs due to use of `x` in closure
+   |                  ^^          -- second borrow occurs due to use of `x` in closure
    |                  |
    |                  second closure is constructed here
 ...

--- a/src/test/ui/borrowck/borrowck-closures-mut-of-mut.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-mut-of-mut.stderr
@@ -2,11 +2,11 @@ error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/borrowck-closures-mut-of-mut.rs:14:18
    |
 LL |     let mut c1 = || set(&mut *x);
-   |                  --           - first borrow occurs due to use of `x` in closure
+   |                  --          -- first borrow occurs due to use of `x` in closure
    |                  |
    |                  first closure is constructed here
 LL |     let mut c2 = || set(&mut *x);
-   |                  ^^           - second borrow occurs due to use of `x` in closure
+   |                  ^^          -- second borrow occurs due to use of `x` in closure
    |                  |
    |                  second closure is constructed here
 LL |

--- a/src/test/ui/borrowck/borrowck-closures-slice-patterns.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-slice-patterns.stderr
@@ -45,7 +45,7 @@ error[E0502]: cannot borrow `*x` as mutable because it is also borrowed as immut
 LL |     let f = || {
    |             -- immutable borrow occurs here
 LL |         let [ref y, ref z @ ..] = *x;
-   |                                    - first borrow occurs due to use of `x` in closure
+   |                                   -- first borrow occurs due to use of `x` in closure
 LL |     };
 LL |     let r = &mut *x;
    |             ^^^^^^^ mutable borrow occurs here
@@ -59,7 +59,7 @@ error[E0501]: cannot borrow `x` as immutable because previous closure requires u
 LL |     let mut f = || {
    |                 -- closure construction occurs here
 LL |         let [ref mut y, ref mut z @ ..] = *x;
-   |                                            - first borrow occurs due to use of `x` in closure
+   |                                           -- first borrow occurs due to use of `x` in closure
 LL |     };
 LL |     let r = &x;
    |             ^^ second borrow occurs here
@@ -86,7 +86,7 @@ error[E0502]: cannot borrow `*x` as mutable because it is also borrowed as immut
 LL |     let f = || {
    |             -- immutable borrow occurs here
 LL |         if let [ref y, ref z @ ..] = *x {}
-   |                                       - first borrow occurs due to use of `x` in closure
+   |                                      -- first borrow occurs due to use of `x` in closure
 LL |     };
 LL |     let r = &mut *x;
    |             ^^^^^^^ mutable borrow occurs here
@@ -100,7 +100,7 @@ error[E0501]: cannot borrow `x` as immutable because previous closure requires u
 LL |     let mut f = || {
    |                 -- closure construction occurs here
 LL |         if let [ref mut y, ref mut z @ ..] = *x {}
-   |                                               - first borrow occurs due to use of `x` in closure
+   |                                              -- first borrow occurs due to use of `x` in closure
 LL |     };
 LL |     let r = &x;
    |             ^^ second borrow occurs here

--- a/src/test/ui/borrowck/borrowck-closures-two-mut-fail.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut-fail.stderr
@@ -59,11 +59,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut-fail.rs:53:24
    |
 LL |     let c1 = to_fn_mut(|| set(&mut *x.f));
-   |                        --           - first borrow occurs due to use of `x` in closure
+   |                        --          ---- first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
-   |                        ^^           - second borrow occurs due to use of `x` in closure
+   |                        ^^          ---- second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |

--- a/src/test/ui/borrowck/borrowck-closures-two-mut.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut.stderr
@@ -59,11 +59,11 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-closures-two-mut.rs:49:24
    |
 LL |     let c1 = to_fn_mut(|| set(&mut *x.f));
-   |                        --           - first borrow occurs due to use of `x` in closure
+   |                        --          ---- first borrow occurs due to use of `x` in closure
    |                        |
    |                        first mutable borrow occurs here
 LL |     let c2 = to_fn_mut(|| set(&mut *x.f));
-   |                        ^^           - second borrow occurs due to use of `x` in closure
+   |                        ^^          ---- second borrow occurs due to use of `x` in closure
    |                        |
    |                        second mutable borrow occurs here
 LL |

--- a/src/test/ui/borrowck/borrowck-closures-unique.rs
+++ b/src/test/ui/borrowck/borrowck-closures-unique.rs
@@ -5,8 +5,6 @@
 // multiple borrows.
 
 
-#![feature(rustc_attrs)]
-
 fn get(x: &isize) -> isize {
     *x
 }
@@ -30,7 +28,7 @@ fn b(x: &mut isize) {
 
 fn c(x: &mut isize) {
     let c1 = || get(x);
-    let c2 = #[rustc_capture_analysis] || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
+    let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
     c1;
 }
 

--- a/src/test/ui/borrowck/borrowck-closures-unique.rs
+++ b/src/test/ui/borrowck/borrowck-closures-unique.rs
@@ -5,6 +5,7 @@
 // multiple borrows.
 
 
+#![feature(rustc_attrs)]
 
 fn get(x: &isize) -> isize {
     *x
@@ -29,7 +30,7 @@ fn b(x: &mut isize) {
 
 fn c(x: &mut isize) {
     let c1 = || get(x);
-    let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
+    let c2 = #[rustc_capture_analysis] || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
     c1;
 }
 

--- a/src/test/ui/borrowck/borrowck-closures-unique.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique.stderr
@@ -20,7 +20,7 @@ LL |     let c1 = || get(x);
    |              |
    |              borrow occurs here
 LL |     let c2 = || { get(x); set(x); };
-   |              ^^       - second borrow occurs due to use of `x` in closure
+   |              ^^               - second borrow occurs due to use of `x` in closure
    |              |
    |              closure construction occurs here
 LL |     c1;

--- a/src/test/ui/borrowck/borrowck-closures-unique.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-unique.stderr
@@ -1,5 +1,5 @@
 error[E0500]: closure requires unique access to `x` but it is already borrowed
-  --> $DIR/borrowck-closures-unique.rs:26:14
+  --> $DIR/borrowck-closures-unique.rs:25:14
    |
 LL |     let c1 = || get(x);
    |              --     - first borrow occurs due to use of `x` in closure
@@ -13,7 +13,7 @@ LL |     c1;
    |     -- first borrow later used here
 
 error[E0500]: closure requires unique access to `x` but it is already borrowed
-  --> $DIR/borrowck-closures-unique.rs:32:14
+  --> $DIR/borrowck-closures-unique.rs:31:14
    |
 LL |     let c1 = || get(x);
    |              --     - first borrow occurs due to use of `x` in closure
@@ -27,7 +27,7 @@ LL |     c1;
    |     -- first borrow later used here
 
 error[E0524]: two closures require unique access to `x` at the same time
-  --> $DIR/borrowck-closures-unique.rs:38:14
+  --> $DIR/borrowck-closures-unique.rs:37:14
    |
 LL |     let c1 = || set(x);
    |              --     - first borrow occurs due to use of `x` in closure
@@ -41,7 +41,7 @@ LL |     c1;
    |     -- first borrow later used here
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/borrowck-closures-unique.rs:43:38
+  --> $DIR/borrowck-closures-unique.rs:42:38
    |
 LL | fn e(x: &'static mut isize) {
    |      - help: consider changing this to be mutable: `mut x`

--- a/src/test/ui/borrowck/borrowck-closures-use-after-free.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-use-after-free.stderr
@@ -4,7 +4,7 @@ error[E0502]: cannot borrow `*ptr` as immutable because it is also borrowed as m
 LL |   let mut test = |foo: &Foo| {
    |                  ----------- mutable borrow occurs here
 LL |     ptr = box Foo { x: ptr.x + 1 };
-   |                        --- first borrow occurs due to use of `ptr` in closure
+   |     --- first borrow occurs due to use of `ptr` in closure
 LL |   };
 LL |   test(&*ptr);
    |   ---- ^^^^^ immutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-insert-during-each.stderr
+++ b/src/test/ui/borrowck/borrowck-insert-during-each.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |         |a| {
    | |         --- closure construction occurs here
 LL | |             f.n.insert(*a);
-   | |             - first borrow occurs due to use of `f` in closure
+   | |             --- first borrow occurs due to use of `f` in closure
 LL | |         })
    | |__________^ second borrow occurs here
 
@@ -24,7 +24,7 @@ LL |
 LL |         |a| {
    |         ^^^ closure construction occurs here
 LL |             f.n.insert(*a);
-   |             - second borrow occurs due to use of `f` in closure
+   |             --- second borrow occurs due to use of `f` in closure
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-loan-blocks-move-cc.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-blocks-move-cc.stderr
@@ -7,7 +7,7 @@ LL |     thread::spawn(move|| {
    |                   ^^^^^^ move out of `v` occurs here
 LL |
 LL |         println!("v={}", *v);
-   |                           - move occurs due to use in closure
+   |                          -- move occurs due to use in closure
 LL |     });
 LL |     w.use_ref();
    |     - borrow later used here
@@ -21,7 +21,7 @@ LL |     thread::spawn(move|| {
    |                   ^^^^^^ move out of `v` occurs here
 LL |
 LL |         println!("v={}", *v);
-   |                           - move occurs due to use in closure
+   |                          -- move occurs due to use in closure
 LL |     });
 LL |     w.use_ref();
    |     - borrow later used here

--- a/src/test/ui/borrowck/borrowck-loan-rcvr.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr.stderr
@@ -7,7 +7,7 @@ LL |     p.blockm(|| {
    |     | immutable borrow later used by call
    |     immutable borrow occurs here
 LL |         p.x = 10;
-   |         - second borrow occurs due to use of `p` in closure
+   |         --- second borrow occurs due to use of `p` in closure
 
 error[E0502]: cannot borrow `p` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-loan-rcvr.rs:34:5

--- a/src/test/ui/borrowck/borrowck-move-by-capture.stderr
+++ b/src/test/ui/borrowck/borrowck-move-by-capture.stderr
@@ -5,10 +5,10 @@ LL |     let bar: Box<_> = box 3;
    |         --- captured outer variable
 LL |     let _g = to_fn_mut(|| {
 LL |         let _h = to_fn_once(move || -> isize { *bar });
-   |                             ^^^^^^^^^^^^^^^^    ---
-   |                             |                   |
-   |                             |                   move occurs because `bar` has type `Box<isize>`, which does not implement the `Copy` trait
-   |                             |                   move occurs due to use in closure
+   |                             ^^^^^^^^^^^^^^^^   ----
+   |                             |                  |
+   |                             |                  move occurs because `bar` has type `Box<isize>`, which does not implement the `Copy` trait
+   |                             |                  move occurs due to use in closure
    |                             move out of `bar` occurs here
 
 error: aborting due to previous error

--- a/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
+++ b/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
@@ -5,11 +5,11 @@ LL |     let t: Box<_> = box 3;
    |         - move occurs because `t` has type `Box<isize>`, which does not implement the `Copy` trait
 LL | 
 LL |     call_f(move|| { *t + 1 });
-   |            ------    - variable moved due to use in closure
+   |            ------   -- variable moved due to use in closure
    |            |
    |            value moved into closure here
 LL |     call_f(move|| { *t + 1 });
-   |            ^^^^^^    - use occurs due to use in closure
+   |            ^^^^^^   -- use occurs due to use in closure
    |            |
    |            value used here after move
 

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/box.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/box.stderr
@@ -13,7 +13,7 @@ error[E0506]: cannot assign to `e.0.0.m.x` because it is borrowed
 LL |     let mut c = || {
    |                 -- borrow of `e.0.0.m.x` occurs here
 LL |         e.0.0.m.x = format!("not-x");
-   |         - borrow occurs due to use in closure
+   |         --------- borrow occurs due to use in closure
 ...
 LL |     e.0.0.m.x = format!("not-x");
    |     ^^^^^^^^^ assignment to borrowed `e.0.0.m.x` occurs here
@@ -27,7 +27,7 @@ error[E0502]: cannot borrow `e.0.0.m.x` as immutable because it is also borrowed
 LL |     let mut c = || {
    |                 -- mutable borrow occurs here
 LL |         e.0.0.m.x = format!("not-x");
-   |         - first borrow occurs due to use of `e.0.0.m.x` in closure
+   |         --------- first borrow occurs due to use of `e.0.0.m.x` in closure
 ...
 LL |     println!("{}", e.0.0.m.x);
    |                    ^^^^^^^^^ immutable borrow occurs here
@@ -41,7 +41,7 @@ error[E0506]: cannot assign to `e.0.0.m.x` because it is borrowed
 LL |     let c = || {
    |             -- borrow of `e.0.0.m.x` occurs here
 LL |         println!("{}", e.0.0.m.x);
-   |                        - borrow occurs due to use in closure
+   |                        --------- borrow occurs due to use in closure
 ...
 LL |     e.0.0.m.x = format!("not-x");
    |     ^^^^^^^^^ assignment to borrowed `e.0.0.m.x` occurs here

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/multilevel-path.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/multilevel-path.stderr
@@ -13,7 +13,7 @@ error[E0499]: cannot borrow `w.p.x` as mutable more than once at a time
 LL |     let mut c = || {
    |                 -- first mutable borrow occurs here
 LL |         w.p.x += 20;
-   |         - first borrow occurs due to use of `w.p.x` in closure
+   |         ----- first borrow occurs due to use of `w.p.x` in closure
 ...
 LL |     let py = &mut w.p.x;
    |              ^^^^^^^^^^ second mutable borrow occurs here

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/simple-struct-min-capture.stderr
@@ -13,7 +13,7 @@ error[E0502]: cannot borrow `p` as immutable because it is also borrowed as muta
 LL |     let mut c = || {
    |                 -- mutable borrow occurs here
 LL |         p.x += 10;
-   |         - first borrow occurs due to use of `p` in closure
+   |         --- first borrow occurs due to use of `p` in closure
 ...
 LL |     println!("{:?}", p);
    |                      ^ immutable borrow occurs here

--- a/src/test/ui/error-codes/E0504.stderr
+++ b/src/test/ui/error-codes/E0504.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     let x = move || {
    |             ^^^^^^^ move out of `fancy_num` occurs here
 LL |         println!("child function: {}", fancy_num.num);
-   |                                        --------- move occurs due to use in closure
+   |                                        ------------- move occurs due to use in closure
 ...
 LL |     println!("main function: {}", fancy_ref.num);
    |                                   ------------- borrow later used here

--- a/src/test/ui/generator/yield-while-ref-reborrowed.stderr
+++ b/src/test/ui/generator/yield-while-ref-reborrowed.stderr
@@ -4,7 +4,7 @@ error[E0501]: cannot borrow `x` as immutable because previous closure requires u
 LL |     let mut b = || {
    |                 -- generator construction occurs here
 LL |         let a = &mut *x;
-   |                       - first borrow occurs due to use of `x` in generator
+   |                      -- first borrow occurs due to use of `x` in generator
 ...
 LL |     println!("{}", x);
    |                    ^ second borrow occurs here

--- a/src/test/ui/issues/issue-11192.stderr
+++ b/src/test/ui/issues/issue-11192.stderr
@@ -5,7 +5,7 @@ LL |     let mut test = |foo: &Foo| {
    |                    ----------- mutable borrow occurs here
 LL |         println!("access {}", foo.x);
 LL |         ptr = box Foo { x: ptr.x + 1 };
-   |                            --- first borrow occurs due to use of `ptr` in closure
+   |         --- first borrow occurs due to use of `ptr` in closure
 ...
 LL |     test(&*ptr);
    |     ---- ^^^^^ immutable borrow occurs here

--- a/src/test/ui/issues/issue-27282-mutate-before-diverging-arm-1.stderr
+++ b/src/test/ui/issues/issue-27282-mutate-before-diverging-arm-1.stderr
@@ -5,7 +5,7 @@ LL |     match x {
    |           - value is immutable in match guard
 ...
 LL |             (|| { *x = None; drop(force_fn_once); })();
-   |              ^^    - borrow occurs due to use of `x` in closure
+   |              ^^   -- borrow occurs due to use of `x` in closure
    |              |
    |              cannot mutably borrow
 

--- a/src/test/ui/issues/issue-27282-mutate-before-diverging-arm-2.stderr
+++ b/src/test/ui/issues/issue-27282-mutate-before-diverging-arm-2.stderr
@@ -5,7 +5,7 @@ LL |     match x {
    |           - value is immutable in match guard
 ...
 LL |                 (|| { *x = None; drop(force_fn_once); })();
-   |                  ^^    - borrow occurs due to use of `x` in closure
+   |                  ^^   -- borrow occurs due to use of `x` in closure
    |                  |
    |                  cannot mutably borrow
 

--- a/src/test/ui/issues/issue-27282-mutate-before-diverging-arm-3.stderr
+++ b/src/test/ui/issues/issue-27282-mutate-before-diverging-arm-3.stderr
@@ -5,7 +5,7 @@ LL |     match **x {
    |           --- value is immutable in match guard
 ...
 LL |             (|| { *x = &None; drop(force_fn_once); })();
-   |              ^^    - borrow occurs due to use of `x` in closure
+   |              ^^   -- borrow occurs due to use of `x` in closure
    |              |
    |              cannot mutably borrow
 

--- a/src/test/ui/issues/issue-27282-reborrow-ref-mut-in-guard.stderr
+++ b/src/test/ui/issues/issue-27282-reborrow-ref-mut-in-guard.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow `r` as mutable, as it is immutable for the pattern g
   --> $DIR/issue-27282-reborrow-ref-mut-in-guard.rs:12:25
    |
 LL |         ref mut r if { (|| { let bar = &mut *r; **bar = false; })();
-   |                         ^^                   - mutable borrow occurs due to use of `r` in closure
+   |                         ^^                  -- mutable borrow occurs due to use of `r` in closure
    |                         |
    |                         cannot borrow as mutable
    |

--- a/src/test/ui/issues/issue-61623.stderr
+++ b/src/test/ui/issues/issue-61623.stderr
@@ -10,7 +10,7 @@ error[E0502]: cannot borrow `*x.1` as mutable because it is also borrowed as imm
   --> $DIR/issue-61623.rs:6:19
    |
 LL |     f2(|| x.0, f1(x.1))
-   |     -- -- -       ^^^ mutable borrow occurs here
+   |     -- -- ---     ^^^ mutable borrow occurs here
    |     |  |  |
    |     |  |  first borrow occurs due to use of `x` in closure
    |     |  immutable borrow occurs here

--- a/src/test/ui/issues/issue-6801.stderr
+++ b/src/test/ui/issues/issue-6801.stderr
@@ -2,7 +2,7 @@ error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/issue-6801.rs:19:13
    |
 LL |       let sq =  || { *x * *x };
-   |                 --    - borrow occurs due to use in closure
+   |                 --   -- borrow occurs due to use in closure
    |                 |
    |                 borrow of `x` occurs here
 LL | 

--- a/src/test/ui/nll/closure-access-spans.stderr
+++ b/src/test/ui/nll/closure-access-spans.stderr
@@ -28,7 +28,7 @@ error[E0500]: closure requires unique access to `x` but it is already borrowed
 LL |     let r = &mut x;
    |             ------ borrow occurs here
 LL |     || *x = 2;
-   |     ^^  - second borrow occurs due to use of `x` in closure
+   |     ^^ -- second borrow occurs due to use of `x` in closure
    |     |
    |     closure construction occurs here
 LL |     r.use_mut();
@@ -88,7 +88,7 @@ LL | fn closure_unique_capture_moved(x: &mut String) {
 LL |     let r = x;
    |             - value moved here
 LL |     || *x = String::new();
-   |     ^^  - borrow occurs due to use in closure
+   |     ^^ -- borrow occurs due to use in closure
    |     |
    |     value borrowed here after move
 

--- a/src/test/ui/nll/closure-borrow-spans.stderr
+++ b/src/test/ui/nll/closure-borrow-spans.stderr
@@ -110,7 +110,7 @@ error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/closure-borrow-spans.rs:65:13
    |
 LL |     let f = || *x = 0;
-   |             --  - borrow occurs due to use in closure
+   |             -- -- borrow occurs due to use in closure
    |             |
    |             borrow of `x` occurs here
 LL |     let y = x;
@@ -122,7 +122,7 @@ error[E0501]: cannot borrow `x` as immutable because previous closure requires u
   --> $DIR/closure-borrow-spans.rs:71:13
    |
 LL |     let f = || *x = 0;
-   |             --  - first borrow occurs due to use of `x` in closure
+   |             -- -- first borrow occurs due to use of `x` in closure
    |             |
    |             closure construction occurs here
 LL |     let y = &x;
@@ -134,7 +134,7 @@ error[E0501]: cannot borrow `x` as mutable because previous closure requires uni
   --> $DIR/closure-borrow-spans.rs:77:13
    |
 LL |     let f = || *x = 0;
-   |             --  - first borrow occurs due to use of `x` in closure
+   |             -- -- first borrow occurs due to use of `x` in closure
    |             |
    |             closure construction occurs here
 LL |     let y = &mut x;
@@ -143,10 +143,10 @@ LL |     f.use_ref();
    |     - first borrow later used here
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/closure-borrow-spans.rs:86:17
+  --> $DIR/closure-borrow-spans.rs:86:16
    |
 LL |         f = || *x = 0;
-   |             --  ^ borrowed value does not live long enough
+   |             -- ^^ borrowed value does not live long enough
    |             |
    |             value captured here
 LL |     }
@@ -158,7 +158,7 @@ error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/closure-borrow-spans.rs:93:5
    |
 LL |     let f = || *x = 0;
-   |             --  - borrow occurs due to use in closure
+   |             -- -- borrow occurs due to use in closure
    |             |
    |             borrow of `*x` occurs here
 LL |     *x = 1;

--- a/src/test/ui/nll/closure-captures.stderr
+++ b/src/test/ui/nll/closure-captures.stderr
@@ -133,9 +133,9 @@ LL |       fn_ref(|| {
 LL | |         ||
    | |         ^^ cannot borrow as mutable
 LL | |         *x = 1;});
-   | |__________-_____- in this closure
-   |            |
-   |            mutable borrow occurs due to use of `x` in closure
+   | |_________--_____- in this closure
+   |           |
+   |           mutable borrow occurs due to use of `x` in closure
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/closure-captures.rs:51:9
@@ -150,9 +150,9 @@ LL |       fn_ref(move || {
 LL | |         ||
    | |         ^^ cannot borrow as mutable
 LL | |         *x = 1;});
-   | |__________-_____- in this closure
-   |            |
-   |            mutable borrow occurs due to use of `x` in closure
+   | |_________--_____- in this closure
+   |           |
+   |           mutable borrow occurs due to use of `x` in closure
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/nll/closure-use-spans.stderr
+++ b/src/test/ui/nll/closure-use-spans.stderr
@@ -6,7 +6,7 @@ LL |     let y = &x;
 LL |     x = 0;
    |     ^^^^^ assignment to borrowed `x` occurs here
 LL |     || *y;
-   |         - borrow later captured here by closure
+   |        -- borrow later captured here by closure
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/closure-use-spans.rs:11:5
@@ -16,7 +16,7 @@ LL |     let y = &mut x;
 LL |     x = 0;
    |     ^^^^^ assignment to borrowed `x` occurs here
 LL |     || *y = 1;
-   |         - borrow later captured here by closure
+   |        -- borrow later captured here by closure
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/closure-use-spans.rs:17:5
@@ -26,7 +26,7 @@ LL |     let y = &x;
 LL |     x = 0;
    |     ^^^^^ assignment to borrowed `x` occurs here
 LL |     move || *y;
-   |              - borrow later captured here by closure
+   |             -- borrow later captured here by closure
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/closures-in-loops.stderr
+++ b/src/test/ui/nll/closures-in-loops.stderr
@@ -21,7 +21,7 @@ error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/closures-in-loops.rs:20:16
    |
 LL |         v.push(|| *x = String::new());
-   |                ^^  - borrows occur due to use of `x` in closure
+   |                ^^ -- borrows occur due to use of `x` in closure
    |                |
    |                closures are constructed here in different iterations of loop
 

--- a/src/test/ui/nll/issue-51268.stderr
+++ b/src/test/ui/nll/issue-51268.stderr
@@ -8,7 +8,7 @@ LL |           self.thing.bar(|| {
    | |
 LL | |
 LL | |             &self.number;
-   | |              ---- first borrow occurs due to use of `self` in closure
+   | |              ----------- first borrow occurs due to use of `self` in closure
 LL | |         });
    | |__________^ mutable borrow occurs here
 


### PR DESCRIPTION
Removed all uses of closures_captures and upvar_capture and refactored code to work with closure_min_captures. This also involved removing functions that were no longer needed like the bridge.

Blessed tests were discussed with Aman.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sexxi-goose/rust/39)
<!-- Reviewable:end -->
