### PR TITLE
First pass for 2229 migrations

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3002,7 +3002,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// # #![deny(disjoint_capture_drop_reorder)]
     /// # #![allow(unused)]
     /// struct FancyInteger(i32);

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2968,6 +2968,7 @@ declare_lint_pass! {
         UNSUPPORTED_NAKED_FUNCTIONS,
         MISSING_ABI,
         SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+        DISJOINT_CAPTURE_DROP_REORDER,
     ]
 }
 
@@ -2992,6 +2993,51 @@ declare_lint! {
     pub UNUSED_DOC_COMMENTS,
     Warn,
     "detects doc comments that aren't used by rustdoc"
+}
+
+declare_lint! {
+    /// The `disjoint_capture_drop_reorder` lint detects variables that aren't completely
+    /// captured when the feature `capture_disjoint_fields` is enabled and it affects the Drop
+    /// order of at least one path starting at this variable.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # #![deny(disjoint_capture_drop_reorder)]
+    /// # #![allow(unused)]
+    /// struct FancyInteger(i32);
+    ///
+    /// impl Drop for FancyInteger {
+    ///     fn drop(&mut self) {
+    ///         println!("Just dropped {}", self.0);
+    ///     }
+    /// }
+    ///
+    /// struct Point { x: FancyInteger, y: FancyInteger }
+    ///
+    /// fn main() {
+    ///   let p = Point { x: FancyInteger(10), y: FancyInteger(20) };
+    ///
+    ///   let c = || {
+    ///      let x = p.x;
+    ///   };
+    ///
+    ///   c();
+    ///
+    ///   // ... More code ...
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// In the above example `p.y` will be dropped at the end of `f` instead of with `c` if
+    /// the feature `capture_disjoint_fields` is enabled.
+    pub DISJOINT_CAPTURE_DROP_REORDER,
+    Allow,
+    "Drop reorder because of `capture_disjoint_fields`"
+
 }
 
 declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1270,7 +1270,7 @@ fn migration_suggestion_for_2229(tcx: TyCtxt<'_>, need_migrations: &Vec<hir::Hir
         need_migrations.iter().map(|v| format!("{}", var_name(tcx, *v))).collect::<Vec<_>>();
     let migrations_list_concat = need_migrations_strings.join(", ");
 
-    format!("let ({}) = ({});", migrations_list_concat, migrations_list_concat)
+    format!("drop(&({}));", migrations_list_concat)
 }
 
 /// Helper function to determine if we need to escalate CaptureKind from

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -650,7 +650,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 }
 
-trait Locatable {
+crate trait Locatable {
     fn to_span(&self, tcx: TyCtxt<'_>) -> Span;
 }
 
@@ -668,7 +668,7 @@ impl Locatable for hir::HirId {
 
 /// The Resolver. This is the type folding engine that detects
 /// unresolved types and so forth.
-struct Resolver<'cx, 'tcx> {
+crate struct Resolver<'cx, 'tcx> {
     tcx: TyCtxt<'tcx>,
     infcx: &'cx InferCtxt<'cx, 'tcx>,
     span: &'cx dyn Locatable,
@@ -679,7 +679,7 @@ struct Resolver<'cx, 'tcx> {
 }
 
 impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
-    fn new(
+    crate fn new(
         fcx: &'cx FnCtxt<'cx, 'tcx>,
         span: &'cx dyn Locatable,
         body: &'tcx hir::Body<'tcx>,

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -12,7 +12,7 @@ fn test1_all_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+    //~| NOTE: drop(&(t, t1, t2));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -30,7 +30,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1) = (t, t1);
+    //~| NOTE: drop(&(t, t1));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -46,7 +46,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (String::new(), String::new());
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         println!("{}", t1.1);
     };
@@ -64,7 +64,7 @@ fn test4_only_non_copy_types_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         let _t1 = t1.0;
     };
@@ -82,7 +82,7 @@ fn test5_only_drop_types_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         let _s = s.0;
     };
@@ -97,7 +97,7 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t1 = (String::new(), String::new());
     let c = move || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t1, t) = (t1, t);
+    //~| NOTE: drop(&(t1, t));
         println!("{} {}", t1.1, t.1);
     };
 
@@ -112,7 +112,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -108,7 +108,7 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 // Note we need migration here only because the non-copy (because Drop type) is captured,
 // otherwise we won't need to, since we can get away with just by ref capture in that case.
 fn test7_drop_non_drop_aggregate_need_migration() {
-    let t = (String::new(), 0i32);
+    let t = (String::new(), String::new(), 0i32);
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -1,0 +1,130 @@
+#![deny(disjoint_capture_drop_reorder)]
+//~^ NOTE: the lint level is defined here
+
+// Test cases for types that implement a insignificant drop (stlib defined)
+
+// `t` needs Drop because one of its elements needs drop,
+// therefore precise capture might affect drop ordering
+fn test1_all_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let t2 = (String::new(), String::new());
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2.0;
+    };
+
+    c();
+}
+
+// String implements drop and therefore should be migrated.
+// But in this test cases, `t2` is completely captured and when it is dropped won't be affected
+fn test2_only_precise_paths_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let t2 = (String::new(), String::new());
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1) = (t, t1);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2;
+    };
+
+    c();
+}
+
+// If a variable would've not been captured by value then it would've not been
+// dropped with the closure and therefore doesn't need migration.
+fn test3_only_by_value_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        println!("{}", t1.1);
+    };
+
+    c();
+}
+
+// Copy types get copied into the closure instead of move. Therefore we don't need to
+// migrate then as their drop order isn't tied to the closure.
+fn test4_only_non_copy_types_need_migration() {
+    let t = (String::new(), String::new());
+
+    // `t1` is Copy because all of its elements are Copy
+    let t1 = (0i32, 0i32);
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        let _t1 = t1.0;
+    };
+
+    c();
+}
+
+fn test5_only_drop_types_need_migration() {
+    struct S(i32, i32);
+
+    let t = (String::new(), String::new());
+
+    // `s` doesn't implement Drop or any elements within it, and doesn't need migration
+    let s = S(0i32, 0i32);
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        let _s = s.0;
+    };
+
+    c();
+}
+
+// Since we are using a move closure here, both `t` and `t1` get moved
+// even though they are being used by ref inside the closure.
+fn test6_move_closures_non_copy_types_might_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let c = move || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t1, t) = (t1, t);
+        println!("{} {}", t1.1, t.1);
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Drop + Non Drop aggregates.
+// Note we need migration here only because the non-copy (because Drop type) is captured,
+// otherwise we won't need to, since we can get away with just by ref capture in that case.
+fn test7_drop_non_drop_aggregate_need_migration() {
+    let t = (String::new(), 0i32);
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+    };
+
+    c();
+}
+
+fn main() {
+    test1_all_need_migration();
+    test2_only_precise_paths_need_migration();
+    test3_only_by_value_need_migration();
+    test4_only_non_copy_types_need_migration();
+    test5_only_drop_types_need_migration();
+    test6_move_closures_non_copy_types_might_need_migration();
+    test7_drop_non_drop_aggregate_need_migration();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -1,0 +1,105 @@
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:13:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2.0;
+LL | |     };
+   | |_____^
+   |
+note: the lint level is defined here
+  --> $DIR/insignificant_drop.rs:1:9
+   |
+LL | #![deny(disjoint_capture_drop_reorder)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: let (t, t1, t2) = (t, t1, t2);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:31:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t, t1) = (t, t1);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:47:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         println!("{}", t1.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:65:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:83:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _s = s.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:98:13
+   |
+LL |       let c = move || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         println!("{} {}", t1.1, t.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t1, t) = (t1, t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:113:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: let (t, t1, t2) = (t, t1, t2);
+   = note: drop(&(t, t1, t2));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:31:13
@@ -31,7 +31,7 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-   = note: let (t, t1) = (t, t1);
+   = note: drop(&(t, t1));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:47:13
@@ -45,7 +45,7 @@ LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:65:13
@@ -59,7 +59,7 @@ LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:83:13
@@ -73,7 +73,7 @@ LL | |         let _s = s.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:98:13
@@ -86,7 +86,7 @@ LL | |         println!("{} {}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t1, t) = (t1, t);
+   = note: drop(&(t1, t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:113:13
@@ -99,7 +99,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/no_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/no_migrations.rs
@@ -1,0 +1,84 @@
+// run-pass
+
+// Set of test cases that don't need migrations
+
+#![deny(disjoint_capture_drop_reorder)]
+
+
+// Copy types as copied by the closure instead of being moved into the closure
+// Therefore their drop order isn't tied to the closure and won't be requiring any
+// migrations.
+fn test1_only_copy_types() {
+    let t = (0i32, 0i32);
+
+    let c = || {
+        let _t = t.0;
+    };
+
+    c();
+}
+
+// Same as test1 but using a move closure
+fn test2_only_copy_types_move_closure() {
+    let t = (0i32, 0i32);
+
+    let c = move || {
+        println!("{}", t.0);
+    };
+
+    c();
+}
+
+// Don't need to migrate if captured by ref
+fn test3_only_copy_types_move_closure() {
+    let t = (String::new(), String::new());
+
+    let c = || {
+        println!("{}", t.0);
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Insignificant Drop + Non Drop aggregates.
+// Note in this test the closure captures a non Drop type and therefore the variable
+// is only captured by ref.
+fn test4_insignificant_drop_non_drop_aggregate() {
+    let t = (String::new(), 0i32);
+
+    let c = || {
+        let _t = t.1;
+    };
+
+    c();
+}
+
+
+struct Foo(i32);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("{:?} dropped", self.0);
+    }
+}
+
+// Test migration analysis in case of Significant Drop + Non Drop aggregates.
+// Note in this test the closure captures a non Drop type and therefore the variable
+// is only captured by ref.
+fn test5_significant_drop_non_drop_aggregate() {
+    let t = (Foo(0), 0i32);
+
+    let c = || {
+        let _t = t.1;
+    };
+
+    c();
+}
+
+fn main() {
+    test1_only_copy_types();
+    test2_only_copy_types_move_closure();
+    test3_only_copy_types_move_closure();
+    test4_insignificant_drop_non_drop_aggregate();
+    test5_significant_drop_non_drop_aggregate();
+
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -85,7 +85,7 @@ fn test4_type_contains_drop_need_migration() {
 // Note we need migration here only because the non-copy (because Drop type) is captured,
 // otherwise we won't need to, since we can get away with just by ref capture in that case.
 fn test5_drop_non_drop_aggregate_need_migration() {
-    let t = (Foo(0), 0i32);
+    let t = (Foo(0), Foo(0), 0i32);
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -1,0 +1,137 @@
+#![deny(disjoint_capture_drop_reorder)]
+//~^ NOTE: the lint level is defined here
+
+// Test cases for types that implement a significant drop (user defined)
+
+#[derive(Debug)]
+struct Foo(i32);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("{:?} dropped", self.0);
+    }
+}
+
+#[derive(Debug)]
+struct ConstainsDropField(Foo, Foo);
+
+// `t` needs Drop because one of its elements needs drop,
+// therefore precise capture might affect drop ordering
+fn test1_all_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0));
+    let t2 = (Foo(0), Foo(0));
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2.0;
+    };
+
+    c();
+}
+
+// String implements drop and therefore should be migrated.
+// But in this test cases, `t2` is completely captured and when it is dropped won't be affected
+fn test2_only_precise_paths_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0));
+    let t2 = (Foo(0), Foo(0));
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1) = (t, t1);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2;
+    };
+
+    c();
+}
+
+// If a variable would've not been captured by value then it would've not been
+// dropped with the closure and therefore doesn't need migration.
+fn test3_only_by_value_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0));
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        println!("{:?}", t1.1);
+    };
+
+    c();
+}
+
+// The root variable might not implement drop themselves but some path starting
+// at the root variable might implement Drop.
+//
+// If this path isn't captured we need to migrate for the root variable.
+fn test4_type_contains_drop_need_migration() {
+    let t = ConstainsDropField(Foo(0), Foo(0));
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Drop + Non Drop aggregates.
+// Note we need migration here only because the non-copy (because Drop type) is captured,
+// otherwise we won't need to, since we can get away with just by ref capture in that case.
+fn test5_drop_non_drop_aggregate_need_migration() {
+    let t = (Foo(0), 0i32);
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Significant and Insignificant Drop aggregates.
+fn test6_significant_insignificant_drop_aggregate_need_migration() {
+    struct S(i32, i32);
+
+    let t = (Foo(0), String::new());
+
+    let c = || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.1;
+    };
+
+    c();
+}
+
+// Since we are using a move closure here, both `t` and `t1` get moved
+// even though they are being used by ref inside the closure.
+fn test7_move_closures_non_copy_types_might_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0), Foo(0));
+
+    let c = move || {
+    //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t1, t) = (t1, t);
+        println!("{:?} {:?}", t1.1, t.1);
+    };
+
+    c();
+}
+
+fn main() {
+    test1_all_need_migration();
+    test2_only_precise_paths_need_migration();
+    test3_only_by_value_need_migration();
+    test4_type_contains_drop_need_migration();
+    test5_drop_non_drop_aggregate_need_migration();
+    test6_significant_insignificant_drop_aggregate_need_migration();
+    test7_move_closures_non_copy_types_might_need_migration();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -23,7 +23,7 @@ fn test1_all_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+    //~| NOTE: drop(&(t, t1, t2));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -41,7 +41,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1) = (t, t1);
+    //~| NOTE: drop(&(t, t1));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -57,7 +57,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         println!("{:?}", t1.1);
     };
@@ -74,7 +74,7 @@ fn test4_type_contains_drop_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
     };
 
@@ -89,7 +89,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
     };
 
@@ -104,7 +104,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.1;
     };
 
@@ -119,7 +119,7 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
 
     let c = move || {
     //~^ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t1, t) = (t1, t);
+    //~| NOTE: drop(&(t1, t));
         println!("{:?} {:?}", t1.1, t.1);
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -1,0 +1,103 @@
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:24:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2.0;
+LL | |     };
+   | |_____^
+   |
+note: the lint level is defined here
+  --> $DIR/significant_drop.rs:1:9
+   |
+LL | #![deny(disjoint_capture_drop_reorder)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: let (t, t1, t2) = (t, t1, t2);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:42:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t, t1) = (t, t1);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:58:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         println!("{:?}", t1.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:75:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:90:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:105:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.1;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:120:13
+   |
+LL |       let c = move || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         println!("{:?} {:?}", t1.1, t.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t1, t) = (t1, t);
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: let (t, t1, t2) = (t, t1, t2);
+   = note: drop(&(t, t1, t2));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:42:13
@@ -31,7 +31,7 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-   = note: let (t, t1) = (t, t1);
+   = note: drop(&(t, t1));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:58:13
@@ -45,7 +45,7 @@ LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:75:13
@@ -58,7 +58,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:90:13
@@ -71,7 +71,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:105:13
@@ -84,7 +84,7 @@ LL | |         let _t = t.1;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:120:13
@@ -97,7 +97,7 @@ LL | |         println!("{:?} {:?}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t1, t) = (t1, t);
+   = note: drop(&(t1, t));
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -7,10 +7,10 @@ LL |             let mut closure1 = || p = &y;
    = note: defining type: test::{closure#0}::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r i32, &'_#2r mut &'_#3r i32),
+               (&'_#1r mut &'_#2r i32, &'_#3r i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#1r: '_#3r
+   = note: where '_#3r: '_#2r
 
 note: external requirements
   --> $DIR/escape-upvar-nested.rs:20:27
@@ -25,10 +25,10 @@ LL | |         };
    = note: defining type: test::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r i32, &'_#2r mut &'_#3r i32),
+               (&'_#1r mut &'_#2r i32, &'_#3r i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#1r: '_#3r
+   = note: where '_#3r: '_#2r
 
 note: no external requirements
   --> $DIR/escape-upvar-nested.rs:13:1

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -7,10 +7,10 @@ LL |         let mut closure = || p = &y;
    = note: defining type: test::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r i32, &'_#2r mut &'_#3r i32),
+               (&'_#1r mut &'_#2r i32, &'_#3r i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#1r: '_#3r
+   = note: where '_#3r: '_#2r
 
 note: no external requirements
   --> $DIR/escape-upvar-ref.rs:17:1


### PR DESCRIPTION
This first pass figures out the list of root variables (and their types) that aren't completely
captured by the closure when `capture_disjoint_fields` is enabled and drop order of
some path starting at this root variable **might** be affected.

The output list would include a root variable if:
- It was would have been moved into the closure when `capture_disjoint_fields` isn't
  enabled, **and**
- It isn't completely captured by the closure.
- The type of the root variable needs Drop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sexxi-goose/rust/42)
<!-- Reviewable:end -->
